### PR TITLE
Add Event Monitoring and Monitoring filtering

### DIFF
--- a/examples/monitor/monitor.go
+++ b/examples/monitor/monitor.go
@@ -141,11 +141,11 @@ func main() {
 	if *event {
 		// start callback-based subscription
 		wg.Add(1)
-		go startCallbackSub(ctx, m, *interval, 0, wg, *event, filterExtObj, *nodeID)
+		go startCallbackSub(ctx, m, *interval, 0, wg, *event, &filterExtObj, *nodeID)
 
 		// start channel-based subscription
 		wg.Add(1)
-		go startChanSub(ctx, m, *interval, 0, wg, *event, filterExtObj, *nodeID)
+		go startChanSub(ctx, m, *interval, 0, wg, *event, &filterExtObj, *nodeID)
 	} else {
 		// start callback-based subscription
 		wg.Add(1)

--- a/examples/subscribe/subscribe.go
+++ b/examples/subscribe/subscribe.go
@@ -133,7 +133,7 @@ func main() {
 
 func valueRequest(nodeID *ua.NodeID) *ua.MonitoredItemCreateRequest {
 	handle := uint32(42)
-	return opcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, handle)
+	return opcua.NewMonitoredItemCreateRequestWithDefaults(nodeID, ua.AttributeIDValue, nil, handle)
 }
 
 func eventRequest(nodeID *ua.NodeID) (*ua.MonitoredItemCreateRequest, []string) {

--- a/examples/trigger/trigger.go
+++ b/examples/trigger/trigger.go
@@ -90,7 +90,7 @@ func main() {
 	}
 
 	miCreateRequests := []*ua.MonitoredItemCreateRequest{
-		opcua.NewMonitoredItemCreateRequestWithDefaults(triggeringNode, ua.AttributeIDValue, 42),
+		opcua.NewMonitoredItemCreateRequestWithDefaults(triggeringNode, ua.AttributeIDValue, nil, 42),
 		{
 			ItemToMonitor: &ua.ReadValueID{
 				NodeID:       triggeredNode,

--- a/monitor/subscription.go
+++ b/monitor/subscription.go
@@ -529,13 +529,10 @@ func parseNodeSlice(nodes ...string) ([]*ua.NodeID, error) {
 	var err error
 
 	nodeIDs := make([]*ua.NodeID, len(nodes))
-	println("8.1")
 	for i, node := range nodes {
 		if nodeIDs[i], err = ua.ParseNodeID(node); err != nil {
-			println("8.2")
 			return nil, err
 		}
 	}
-	println("8.3")
 	return nodeIDs, nil
 }

--- a/subscription.go
+++ b/subscription.go
@@ -52,7 +52,7 @@ type monitoredItem struct {
 	ts  ua.TimestampsToReturn
 }
 
-func NewMonitoredItemCreateRequestWithDefaults(nodeID *ua.NodeID, attributeID ua.AttributeID, clientHandle uint32) *ua.MonitoredItemCreateRequest {
+func NewMonitoredItemCreateRequestWithDefaults(nodeID *ua.NodeID, attributeID ua.AttributeID, filter *ua.ExtensionObject, clientHandle uint32) *ua.MonitoredItemCreateRequest {
 	if attributeID == 0 {
 		attributeID = ua.AttributeIDValue
 	}
@@ -66,11 +66,30 @@ func NewMonitoredItemCreateRequestWithDefaults(nodeID *ua.NodeID, attributeID ua
 		RequestedParameters: &ua.MonitoringParameters{
 			ClientHandle:     clientHandle,
 			DiscardOldest:    true,
-			Filter:           nil,
+			Filter:           filter,
 			QueueSize:        10,
 			SamplingInterval: 0.0,
 		},
 	}
+}
+func NewMonitoredItemCreateRequestForEvents(nodeID *ua.NodeID, filter *ua.ExtensionObject, clientHandle uint32) *ua.MonitoredItemCreateRequest {
+	req := &ua.MonitoredItemCreateRequest{
+		ItemToMonitor: &ua.ReadValueID{
+			NodeID:       nodeID,
+			AttributeID:  ua.AttributeIDEventNotifier,
+			DataEncoding: &ua.QualifiedName{},
+		},
+		MonitoringMode: ua.MonitoringModeReporting,
+		RequestedParameters: &ua.MonitoringParameters{
+			ClientHandle:     clientHandle,
+			DiscardOldest:    true,
+			Filter:           filter,
+			QueueSize:        10,
+			SamplingInterval: 1.0,
+		},
+	}
+
+	return req
 }
 
 type PublishNotificationData struct {
@@ -141,6 +160,7 @@ func (s *Subscription) Monitor(ctx context.Context, ts ua.TimestampsToReturn, it
 			ts:  ts,
 		}
 	}
+
 	s.itemsMu.Unlock()
 
 	return res, err

--- a/uatest/reconnection_test.go
+++ b/uatest/reconnection_test.go
@@ -91,6 +91,7 @@ func TestAutoReconnection(t *testing.T) {
 		&opcua.SubscriptionParameters{Interval: opcua.DefaultSubscriptionInterval},
 		ch,
 		false,
+		nil,
 		currentTimeNodeID,
 	)
 	if err != nil {

--- a/uatest/reconnection_test.go
+++ b/uatest/reconnection_test.go
@@ -90,6 +90,7 @@ func TestAutoReconnection(t *testing.T) {
 		sctx,
 		&opcua.SubscriptionParameters{Interval: opcua.DefaultSubscriptionInterval},
 		ch,
+		false,
 		currentTimeNodeID,
 	)
 	if err != nil {


### PR DESCRIPTION
changes can be tested using:

go run examples/monitor/monitor.go -endpoint opc.tcp://0.0.0.0:4840  -node 'i=2253' -event=true

will make a PR in the opensource once approved unless you think otherwise.